### PR TITLE
Keep active ChatGPT workspace leases alive

### DIFF
--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Mac Developer Bridge Background Browser",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "Lets Mac Developer Bridge operate approved Chrome tabs without bringing Chrome to the foreground.",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAq9QjCNUI8xWx8wNSCITv4TFRy2pYhd77cDUTmYFJqduaYwhplrkvbo1BB9wTn7VBKLe8ohNp4fnZz9T03il69oRPsYGRb5aHAdSVaYdCrOiGs7GN00wvwUf6d2lQeuslDd53SpTnXZdtGRMVRBeK4X4NyEksQHzxKpaeaRlT0R9qREp+TdiLfEh5Z6UImZ0ZeBVn7efazrNBYMARBjas3A/AbXUyH654TVMOAqePUpgj129g8ZGQjcPqOFKGqhAyyCVhpbJBU+1Kt7sX6wbIIREtjmryW7sqMba7TnubqCv2qTPLZNeHQVQaQpl75cYdL26lh8PXwSTHeQKX+3KwHwIDAQAB",
   "permissions": [

--- a/chrome-extension/service-worker.js
+++ b/chrome-extension/service-worker.js
@@ -467,7 +467,7 @@ async function touchWorkspaceLease(tabId) {
 }
 
 async function startWorkspaceLeaseHeartbeat(tabId) {
-  if (!await touchWorkspaceLease(tabId)) return () => {};
+  if (!await touchWorkspaceLease(tabId).catch(() => false)) return () => {};
   let stopped = false;
   const timer = setInterval(() => {
     if (stopped) return;

--- a/chrome-extension/service-worker.js
+++ b/chrome-extension/service-worker.js
@@ -1,5 +1,5 @@
 const NATIVE_HOST = "io.github.alexanderradahl.mac_developer_bridge";
-const VERSION = "0.2.10";
+const VERSION = "0.2.11";
 const WORKSPACE_KEY = "macDeveloperBridgeWorkspace";
 const WORKSPACE_TARGET_KEY = "macDeveloperBridgeWorkspaceTarget";
 const WORKSPACE_GROUP_TITLE = "MDB";

--- a/chrome-extension/service-worker.js
+++ b/chrome-extension/service-worker.js
@@ -5,6 +5,7 @@ const WORKSPACE_TARGET_KEY = "macDeveloperBridgeWorkspaceTarget";
 const WORKSPACE_GROUP_TITLE = "MDB";
 const WORKSPACE_GROUP_COLOR = "blue";
 const WORKSPACE_LEASE_IDLE_TIMEOUT_MS = 10 * 60 * 1000;
+const WORKSPACE_LEASE_HEARTBEAT_INTERVAL_MS = 60_000;
 const WORKSPACE_LEASE_WAIT_TIMEOUT_MS = 20_000;
 const WORKSPACE_LEASE_WAIT_POLL_MS = 250;
 const WORKSPACE_NAVIGATION_TIMEOUT_MS = 15_000;
@@ -463,6 +464,20 @@ async function touchWorkspaceLease(tabId) {
     await saveWorkspaceState({ groupId: state.groupId, tabIds: state.tabIds, leases: state.leases });
     return true;
   });
+}
+
+async function startWorkspaceLeaseHeartbeat(tabId) {
+  if (!await touchWorkspaceLease(tabId)) return () => {};
+  let stopped = false;
+  const timer = setInterval(() => {
+    if (stopped) return;
+    touchWorkspaceLease(tabId).catch(() => {});
+  }, WORKSPACE_LEASE_HEARTBEAT_INTERVAL_MS);
+  return () => {
+    if (stopped) return;
+    stopped = true;
+    clearInterval(timer);
+  };
 }
 
 async function reserveIdleWorkspaceTab() {
@@ -3413,12 +3428,14 @@ async function dispatch(message) {
         }
         await touchWorkspaceLease(tab.id);
       }
+      let stopWorkspaceLeaseHeartbeat = () => {};
       try {
         if (!tab || !String(tab.url || "").startsWith("https://chatgpt.com/")) {
           const error = new Error("The selected tab is not a chatgpt.com page.");
           error.code = "CHATGPT_TAB_UNAVAILABLE";
           throw error;
         }
+        stopWorkspaceLeaseHeartbeat = await startWorkspaceLeaseHeartbeat(tab.id);
         const pageFunction = transport === "runtime"
           ? pageChatgptRuntimeConversationStart
           : pageChatgptConversationStart;
@@ -3484,6 +3501,7 @@ async function dispatch(message) {
           tab_active: Boolean(settledTab?.active ?? tab.active),
         };
       } finally {
+        stopWorkspaceLeaseHeartbeat();
         if (autoLeased && tab?.id != null) await releaseWorkspaceTab(tab.id).catch(() => {});
       }
     }

--- a/tests/chrome-background.mjs
+++ b/tests/chrome-background.mjs
@@ -203,14 +203,14 @@ try {
   assert.ok(manifest.permissions.includes("tabGroups"));
   assert.ok(manifest.permissions.includes("storage"));
   assert.ok(manifest.icons?.["16"] && manifest.icons?.["128"]);
-  assert.equal(manifest.version, "0.2.10");
+  assert.equal(manifest.version, "0.2.11");
   assert.equal(manifest.permissions.includes("debugger"), false, "realistic click support must not require Chrome debugger permission");
   await Promise.all([16, 32, 48, 128].map(async (size) => {
     const stat = await fs.stat(path.join(root, "chrome-extension", "icons", `icon-${size}.png`));
     assert.ok(stat.size > 0, `expected non-empty ${size}px extension icon`);
   }));
   const workerSource = await fs.readFile(path.join(root, "chrome-extension", "service-worker.js"), "utf8");
-  assert.match(workerSource, /const VERSION = "0\.2\.10"/);
+  assert.match(workerSource, /const VERSION = "0\.2\.11"/);
   assert.match(workerSource, /WORKSPACE_GROUP_TITLE = "MDB"/);
   assert.match(workerSource, /chrome\.tabs\.group/);
   assert.match(workerSource, /chrome\.tabGroups\.query/);

--- a/tests/chrome-workspace-capacity.mjs
+++ b/tests/chrome-workspace-capacity.mjs
@@ -171,6 +171,19 @@ noopStopper();
 noopStopper();
 assert.equal(heartbeatClearCalls, 0);
 
+let chatgptExecuteCalls = 0;
+touchImplementation = async () => {
+  throw new Error("initial lease renewal failed");
+};
+const stopAfterInitialFailure = await startHeartbeat(73);
+try {
+  chatgptExecuteCalls += 1;
+} finally {
+  stopAfterInitialFailure();
+}
+assert.equal(chatgptExecuteCalls, 1, "a rejected initial renewal must not prevent ChatGPT execution");
+assert.equal(heartbeatTimers.length, 0, "a rejected initial renewal must not start a timer");
+
 let activeTouchCalls = 0;
 touchImplementation = async (tabId) => {
   touchedTabIds.push(tabId);

--- a/tests/chrome-workspace-capacity.mjs
+++ b/tests/chrome-workspace-capacity.mjs
@@ -117,6 +117,90 @@ assert.equal(storageWrites.length, 0, "a lower request must not shrink or rewrit
 assert.equal(await provisionTarget(20, 8), 20);
 assert.equal(storageWrites.at(-1).macDeveloperBridgeWorkspaceTarget.targetPoolSize, 20);
 
+// Long-running ChatGPT conversations must keep their workspace lease active
+// without letting a failed renewal replace the conversation result.
+const heartbeatIntervalMatch = workerSource.match(
+  /const WORKSPACE_LEASE_HEARTBEAT_INTERVAL_MS = ([^;]+);/,
+);
+assert.ok(heartbeatIntervalMatch, "workspace lease heartbeat interval should be declared");
+const heartbeatIntervalMs = vm.runInNewContext(heartbeatIntervalMatch[1]);
+assert.ok(heartbeatIntervalMs > 0);
+assert.ok(heartbeatIntervalMs < 10 * 60 * 1000);
+
+const heartbeatHelperMatch = workerSource.match(
+  /async function startWorkspaceLeaseHeartbeat[\s\S]*?\n}\n\n(?=async function reserveIdleWorkspaceTab)/,
+);
+assert.ok(heartbeatHelperMatch, "workspace lease heartbeat helper should be extractable");
+const heartbeatTimers = [];
+let heartbeatClearCalls = 0;
+let touchImplementation;
+const heartbeatContext = vm.createContext({
+  WORKSPACE_LEASE_HEARTBEAT_INTERVAL_MS: heartbeatIntervalMs,
+  touchWorkspaceLease: async (tabId) => await touchImplementation(tabId),
+  setInterval(callback, delayMs) {
+    const timer = { callback, delayMs, cleared: false };
+    heartbeatTimers.push(timer);
+    return timer;
+  },
+  clearInterval(timer) {
+    heartbeatClearCalls += 1;
+    timer.cleared = true;
+  },
+});
+vm.runInContext(heartbeatHelperMatch[0], heartbeatContext);
+const startHeartbeat = vm.runInContext("startWorkspaceLeaseHeartbeat", heartbeatContext);
+
+let resolveInitialTouch;
+const touchedTabIds = [];
+touchImplementation = async (tabId) => {
+  touchedTabIds.push(tabId);
+  return await new Promise((resolve) => { resolveInitialTouch = resolve; });
+};
+const pendingNoopStopper = startHeartbeat(71);
+assert.deepEqual(touchedTabIds, [71]);
+assert.equal(heartbeatTimers.length, 0, "timer must wait for the immediate lease touch");
+resolveInitialTouch(false);
+const noopStopper = await pendingNoopStopper;
+assert.equal(typeof noopStopper, "function");
+assert.equal(heartbeatTimers.length, 0, "an inactive lease must not start a timer");
+noopStopper();
+noopStopper();
+assert.equal(heartbeatClearCalls, 0);
+
+let activeTouchCalls = 0;
+touchImplementation = async (tabId) => {
+  touchedTabIds.push(tabId);
+  activeTouchCalls += 1;
+  if (activeTouchCalls === 1) return true;
+  throw new Error("heartbeat renewal failed");
+};
+const stopHeartbeat = await startHeartbeat(72);
+assert.equal(activeTouchCalls, 1);
+assert.equal(heartbeatTimers.length, 1);
+assert.equal(heartbeatTimers[0].delayMs, heartbeatIntervalMs);
+heartbeatTimers[0].callback();
+await new Promise((resolve) => setImmediate(resolve));
+assert.equal(activeTouchCalls, 2, "the timer should renew the active lease");
+stopHeartbeat();
+stopHeartbeat();
+assert.equal(heartbeatClearCalls, 1, "the synchronous stopper should be idempotent");
+assert.equal(heartbeatTimers[0].cleared, true);
+
+const conversationCase = workerSource.match(
+  /case "tabs\.chatgptConversationStart":[\s\S]*?(?=\n    case "tabs\.chatgptRuntimeInventory")/,
+)?.[0] || "";
+const urlValidationIndex = conversationCase.indexOf("startsWith(\"https://chatgpt.com/\")");
+const heartbeatStartIndex = conversationCase.indexOf("await startWorkspaceLeaseHeartbeat(tab.id)");
+const firstExecuteIndex = conversationCase.indexOf("await executeInTab(tab.id");
+assert.ok(urlValidationIndex >= 0);
+assert.ok(heartbeatStartIndex > urlValidationIndex, "heartbeat should start after ChatGPT URL validation");
+assert.ok(firstExecuteIndex > heartbeatStartIndex, "heartbeat should start before the first page execution");
+assert.match(
+  conversationCase,
+  /finally \{[\s\S]*?stopWorkspaceLeaseHeartbeat\(\);[\s\S]*?releaseWorkspaceTab\(tab\.id\)/,
+  "heartbeat should stop before the existing automatic release",
+);
+
 // Provisioning is accepted while Chrome is unfocused, but actual tab creation
 // remains structurally deferred until natural focus.
 const provisioningMatch = workerSource.match(

--- a/tests/chrome-workspace-capacity.mjs
+++ b/tests/chrome-workspace-capacity.mjs
@@ -6,6 +6,10 @@ import vm from "node:vm";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const workerSource = await fs.readFile(path.join(root, "chrome-extension", "service-worker.js"), "utf8");
+const manifest = JSON.parse(await fs.readFile(path.join(root, "chrome-extension", "manifest.json"), "utf8"));
+const workerVersion = workerSource.match(/const VERSION = "([^"]+)";/)?.[1];
+assert.equal(workerVersion, manifest.version, "service worker and manifest versions should match");
+assert.equal(workerVersion, "0.2.11");
 const helperMatch = workerSource.match(
   /function normalizeWorkspacePoolSize[\s\S]*?\n}\n\n(?=function errorPayload)/,
 );
@@ -185,6 +189,122 @@ stopHeartbeat();
 stopHeartbeat();
 assert.equal(heartbeatClearCalls, 1, "the synchronous stopper should be idempotent");
 assert.equal(heartbeatTimers[0].cleared, true);
+
+const reconcileLeaseMatch = workerSource.match(
+  /async function reconcileWorkspaceStateUnlocked[\s\S]*?\n}\n\n(?=async function reconcileWorkspaceState)/,
+);
+const touchLeaseMatch = workerSource.match(
+  /async function touchWorkspaceLease[\s\S]*?\n}\n\n(?=async function startWorkspaceLeaseHeartbeat)/,
+);
+const reserveLeaseMatch = workerSource.match(
+  /async function reserveIdleWorkspaceTab[\s\S]*?\n}\n\n(?=async function leaseWorkspaceTab)/,
+);
+const releaseLeaseMatch = workerSource.match(
+  /async function releaseWorkspaceTab[\s\S]*?\n}\n\n(?=async function workspaceStatus)/,
+);
+assert.ok(reconcileLeaseMatch && touchLeaseMatch && reserveLeaseMatch && releaseLeaseMatch);
+
+const leasedTabId = 72;
+const idleUrl = "chrome-extension://test/workspace.html";
+let leaseNow = 1_000_000;
+let persistedLeaseState = {
+  groupId: 9,
+  tabIds: [leasedTabId],
+  leases: {
+    [leasedTabId]: { leasedAt: leaseNow, lastActivityAt: leaseNow },
+  },
+};
+let leasedTab = {
+  id: leasedTabId,
+  groupId: 9,
+  url: "https://chatgpt.com/c/active-conversation",
+  active: false,
+};
+let failNextLeaseSave = false;
+let leaseMutationQueue = Promise.resolve();
+const leaseUpdates = [];
+const leaseTimers = [];
+const leaseContext = vm.createContext({
+  WORKSPACE_LEASE_IDLE_TIMEOUT_MS: 10 * 60 * 1000,
+  WORKSPACE_LEASE_HEARTBEAT_INTERVAL_MS: heartbeatIntervalMs,
+  Date: { now: () => leaseNow },
+  numericTabId: (value) => Number(value),
+  workspaceIdleUrl: () => idleUrl,
+  mutateWorkspaceState(operation) {
+    const result = leaseMutationQueue.then(operation, operation);
+    leaseMutationQueue = result.catch(() => {});
+    return result;
+  },
+  loadWorkspaceState: async () => structuredClone(persistedLeaseState),
+  saveWorkspaceState: async (state) => {
+    if (failNextLeaseSave) {
+      failNextLeaseSave = false;
+      throw new Error("simulated heartbeat storage failure");
+    }
+    persistedLeaseState = structuredClone(state);
+  },
+  discoverWorkspaceState: async () => null,
+  clearWorkspaceState: async () => { persistedLeaseState = null; },
+  readGroup: async (groupId) => ({ id: groupId }),
+  readTab: async (tabId) => tabId === leasedTabId ? { ...leasedTab } : null,
+  setWorkspaceGroupActivity: async () => {},
+  setInterval(callback, delayMs) {
+    const timer = { callback, delayMs, cleared: false };
+    leaseTimers.push(timer);
+    return timer;
+  },
+  clearInterval(timer) { timer.cleared = true; },
+  chrome: {
+    tabs: {
+      async update(tabId, options) {
+        leaseUpdates.push({ tabId, options });
+        leasedTab = { ...leasedTab, ...options };
+        return { ...leasedTab };
+      },
+    },
+  },
+});
+vm.runInContext([
+  reconcileLeaseMatch[0],
+  touchLeaseMatch[0],
+  heartbeatHelperMatch[0],
+  reserveLeaseMatch[0],
+  releaseLeaseMatch[0],
+].join("\n\n"), leaseContext);
+const startStatefulHeartbeat = vm.runInContext("startWorkspaceLeaseHeartbeat", leaseContext);
+const reserveStatefulTab = vm.runInContext("reserveIdleWorkspaceTab", leaseContext);
+const releaseStatefulTab = vm.runInContext("releaseWorkspaceTab", leaseContext);
+const reconcileStatefulWorkspace = vm.runInContext("reconcileWorkspaceStateUnlocked", leaseContext);
+
+const stopStatefulHeartbeat = await startStatefulHeartbeat(leasedTabId);
+leaseNow += 10 * 60 * 1000 + 1;
+leaseTimers[0].callback();
+const competingReservation = await reserveStatefulTab();
+assert.equal(competingReservation.tab, null, "a renewed conversation lease must remain reserved");
+assert.ok(persistedLeaseState.leases[leasedTabId]);
+assert.equal(persistedLeaseState.leases[leasedTabId].lastActivityAt, leaseNow);
+assert.equal(leasedTab.url, "https://chatgpt.com/c/active-conversation");
+assert.equal(leaseUpdates.length, 0, "active conversation must not be reclaimed to workspace idle");
+
+// A rejected renewal remains background-only and must not prevent finally-style
+// stop/release cleanup from running afterward.
+failNextLeaseSave = true;
+leaseNow += heartbeatIntervalMs;
+leaseTimers[0].callback();
+stopStatefulHeartbeat();
+const releasedLease = await releaseStatefulTab(leasedTabId);
+assert.equal(releasedLease.released, true);
+assert.equal(leaseTimers[0].cleared, true);
+assert.deepEqual(persistedLeaseState.leases, {});
+assert.equal(leasedTab.url, idleUrl);
+
+const reclaimedReservation = await reserveStatefulTab();
+assert.equal(reclaimedReservation.tab.id, leasedTabId, "released tab should be reservable again");
+leaseNow += 10 * 60 * 1000 + 1;
+const staleReconciliation = await reconcileStatefulWorkspace({ releaseStale: true });
+assert.deepEqual(JSON.parse(JSON.stringify(staleReconciliation.staleReleasedTabIds)), [leasedTabId]);
+assert.deepEqual(persistedLeaseState.leases, {});
+assert.equal(leasedTab.url, idleUrl);
 
 const conversationCase = workerSource.match(
   /case "tabs\.chatgptConversationStart":[\s\S]*?(?=\n    case "tabs\.chatgptRuntimeInventory")/,


### PR DESCRIPTION
## Summary
- renew active ChatGPT workspace leases every 60 seconds during long page execution
- stop the heartbeat before normal workspace release while preserving stale-lease reclamation
- bump the background extension contract to 0.2.11 and add fake-time reconciliation coverage

## Test plan
- npm test
- npm run check
- node tests/chrome-workspace-capacity.mjs
- node tests/chrome-background.mjs
- git diff --check